### PR TITLE
Search by name and id

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint:fix": "eslint --fix src/**/*.ts",
     "test": "jest --detectOpenHandles --forceExit",
     "dev": "cross-env NODE_ENV=develop NODE_PATH=./src nodemon src/index.ts",
-    "serve": "cross-env NODE_ENV=prod NODE_PATH=./dist node dist/index.js"
+    "serve": "cross-env NODE_ENV=prod NODE_PATH=./dist node dist/index.js",
+    "prisma:push": "npx prisma db push && npx prisma generate"
   },
   "author": "오명훈 <omh02033@gmail.com>",
   "license": "MIT",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,8 +32,7 @@ model Profile {
 }
 
 model Question {
-  id           Int      @id @default(autoincrement())
-  postId       Int
+  id           String   @id @default(cuid())
   createAt     DateTime @default(now())
   type         Type     @default(anonymous)
   status       Status   @default(received)
@@ -49,7 +48,7 @@ model Question {
 }
 
 model Like {
-  questionId Int
+  questionId String
   userName   String
 
   @@id([questionId, userName])

--- a/src/routes/post/answer.controller.ts
+++ b/src/routes/post/answer.controller.ts
@@ -9,16 +9,11 @@ export default async function (
   res: Response,
   next: NextFunction
 ) {
-  const userName = req.user;
   const { questionId, post, status } = req.body;
 
   try {
     const { count } = await prisma.question.updateMany({
-      where: {
-        receiverName: userName,
-        postId: +questionId,
-        status: 'received',
-      },
+      where: { id: questionId, status: 'received' },
       data: {
         answer: status === 'accepted' ? post : '',
         status,

--- a/src/routes/post/question.controller.ts
+++ b/src/routes/post/question.controller.ts
@@ -24,22 +24,17 @@ export default async function (
       return next(new HttpException(400, 'wrong receiver'));
     }
 
-    const newQuestionId: number =
-      (await prisma.question.count({
-        where: { receiverName: receiver },
-      })) + 1;
-
-    await prisma.question.create({
+    const { id } = await prisma.question.create({
       data: {
         type,
         question: xss(post),
         receiverName: receiver,
         authorName: type === 'onymous' ? userName : null,
-        postId: newQuestionId,
       },
+      select: { id: true },
     });
 
-    res.jsend.success({ id: newQuestionId });
+    res.jsend.success({ id });
   } catch (error) {
     if (error.code === 'P2003') {
       return next(new HttpException(400, 'invalid receiver id', error));

--- a/src/routes/upload/upload.controller.ts
+++ b/src/routes/upload/upload.controller.ts
@@ -13,7 +13,7 @@ export default async function (
 ): Promise<void> {
   try {
     const resizedImage = await sharp(req.file.buffer)
-      .resize(200, 200)
+      .resize(100, 100)
       .toBuffer();
 
     const {

--- a/src/routes/user/find.controller.ts
+++ b/src/routes/user/find.controller.ts
@@ -10,10 +10,16 @@ export default async function (
   next: NextFunction
 ) {
   try {
+    const keyword = req.query.keyword;
     res.jsend.success(
       await prisma.profile.findMany({
-        where: { userName: { contains: req.query.name } },
-        take: req.query.preview === 'true' ? 5 : undefined,
+        where: {
+          OR: [
+            { userName: { contains: keyword } },
+            { id: { contains: keyword } },
+          ],
+        },
+        take: req.query.preview === 'true' ? 10 : undefined,
         select: {
           email: true,
           userName: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,4 +34,4 @@ export interface LikeBody {
   questionId: Like['questionId'];
 }
 
-export type FindUserParams = Partial<Record<'name' | 'preview', string>>;
+export type FindUserParams = Partial<Record<'keyword' | 'preview', string>>;


### PR DESCRIPTION
아이디와 이름으로 사용자를 검색할 수 있습니다.
현재 정렬 순서는 알파벳 순이고, 이후 팔로워수를 고려하여 수정될 예정입니다.
그리고 `/user/find`의 query가 `name`에서 `keyword`로 변경되었습니다. 문서를 확인해주세요.